### PR TITLE
Load service impls with TCCL and current classloader

### DIFF
--- a/server/src/main/java/org/asciidoctor/diagram/CommandServer.java
+++ b/server/src/main/java/org/asciidoctor/diagram/CommandServer.java
@@ -39,8 +39,12 @@ public class CommandServer {
     {
         Map<String, DiagramGenerator> generatorMap = new HashMap<String, DiagramGenerator>();
 
-        ServiceLoader<DiagramGenerator> generatorLoader = ServiceLoader.load(DiagramGenerator.class);
+        ServiceLoader<DiagramGenerator> generatorLoader = ServiceLoader.load(DiagramGenerator.class, CommandServer.class.getClassLoader());
         for (DiagramGenerator generator : generatorLoader) {
+            generatorMap.put(generator.getName(), generator);
+        }
+        ServiceLoader<DiagramGenerator> generatorLoaderTCCL = ServiceLoader.load(DiagramGenerator.class);
+        for (DiagramGenerator generator : generatorLoaderTCCL) {
             generatorMap.put(generator.getName(), generator);
         }
         return generatorMap;


### PR DESCRIPTION
Currently asciidoctor-diagram loads all concrete implementations for diagrams with a ServiceLoader that uses the TCCL by default.
This creates problems in AsciidoctorJ where the TCCL is not set to the JRubyClassLoader by default.
The fix on AsciidoctorJ's side would be to set the TCCL, but this can be problematic at least in JavaEE environments where extensions would invoke JavaEE components.

This should also be fixable in Asciidoctor-Diagram by using the TCCL *and* the classloader that loaded the CommandServer class and merging all implementations.